### PR TITLE
Upgrade Gradle to avoid dex merge error

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
First of all, thanks for this demo! Really helpful.

A bug in Gradle 6.9 causes failed builds:

- https://github.com/gradle/gradle/issues/15536
- https://github.com/gradle/gradle/issues/19372

It results in the following error:

```
com.android.builder.dexing.DexArchiveMergerException: Error while merging dex archives:
...
> Task :app:mergeExtDexRelease FAILED
...
Type androidx.appcompat.app.ActionBar$DisplayOptions is defined multiple times
```

Apparently Expo's Gradle has been updated to 7.3.3 in the meantime, but not yet released:

https://github.com/expo/expo/commit/d566f199bdb03f738c8a785283e847b6a00ec37a